### PR TITLE
fixing sums and counts eng-1533 

### DIFF
--- a/terraform-aws/alb.tf
+++ b/terraform-aws/alb.tf
@@ -60,7 +60,7 @@ resource "aws_lb_target_group" "esearch-p9200-tg" {
 }
 
 resource "aws_lb_target_group" "kibana-p5601-tg" {
-  count    = length(keys(var.clients_count)) > 0 || local.singlenode_mode ? 1 : 0
+  count    = sum(values(var.clients_count)) > 0 || local.singlenode_mode ? 1 : 0
   name     = "${var.es_cluster}-p5601-tg"
   port     = 5601
   protocol = "HTTP"
@@ -104,7 +104,7 @@ resource "aws_lb_listener" "esearch" {
 }
 
 resource "aws_lb_listener" "kibana" {
-  count    = length(keys(var.clients_count)) > 0 || local.singlenode_mode ? 1 : 0
+  count    = sum(values(var.clients_count)) > 0 || local.singlenode_mode ? 1 : 0
   load_balancer_arn = aws_lb.elasticsearch-alb.arn
   port              = "5601"
   protocol          = "HTTP"

--- a/terraform-aws/client.tf
+++ b/terraform-aws/client.tf
@@ -31,7 +31,7 @@ resource "aws_launch_template" "client" {
 }
 
 resource "aws_autoscaling_group" "client_nodes" {
-  count = length(keys(var.clients_count))
+  count = sum(values(var.clients_count)) == 0 ? 0 : 1
 
   name               = "elasticsearch-${var.es_cluster}-client-nodes-${keys(var.clients_count)[count.index]}"
   max_size           = var.clients_count[keys(var.clients_count)[count.index]]

--- a/terraform-aws/data-voters-blue.tf
+++ b/terraform-aws/data-voters-blue.tf
@@ -5,7 +5,7 @@ module "data-voters-blue" {
   
   # nodes
   node_count = var.data_voters_blue_count
-  singlenode_mode = false
+  singlenode_mode = local.singlenode_mode
   image = var.elasticsearch_blue_ami_id
   instance_type = var.data_blue_instance_type
   heap_size = var.data_blue_heap_size

--- a/terraform-aws/datas-blue.tf
+++ b/terraform-aws/datas-blue.tf
@@ -5,7 +5,7 @@ module "data-blue" {
   
   # nodes
   node_count = var.datas_blue_count
-  singlenode_mode = false
+  singlenode_mode = local.singlenode_mode
   image = var.elasticsearch_blue_ami_id
   instance_type = var.data_blue_instance_type
   heap_size = var.data_blue_heap_size

--- a/terraform-aws/datas-voters.tf
+++ b/terraform-aws/datas-voters.tf
@@ -34,7 +34,7 @@ resource "aws_launch_template" "data_voters" {
 }
 
 resource "aws_autoscaling_group" "data_voters_nodes" {
-  count = length(keys(var.data_voters_count))
+  count = sum(values(var.data_voters_count)) == 0 ? 0 : 1
 
   name               = "elasticsearch-${var.es_cluster}-data-voters-nodes-${keys(var.data_voters_count)[count.index]}"
   max_size           = var.data_voters_count[keys(var.data_voters_count)[count.index]]

--- a/terraform-aws/datas.tf
+++ b/terraform-aws/datas.tf
@@ -34,7 +34,7 @@ resource "aws_launch_template" "data" {
 }
 
 resource "aws_autoscaling_group" "data_nodes" {
-  count = length(keys(var.datas_count))
+  count = sum(values(var.datas_count)) == 0 ? 0 : 1
 
   name               = "elasticsearch-${var.es_cluster}-data-nodes-${keys(var.datas_count)[count.index]}"
   max_size           = var.datas_count[keys(var.datas_count)[count.index]]

--- a/terraform-aws/main.tf
+++ b/terraform-aws/main.tf
@@ -34,11 +34,11 @@ locals {
 
   flat_clients_subnet_ids = flatten(values(local.clients_subnet_ids))
 
-  singlenode_mode = sum(try([for v in values(var.masters_blue_count) : v], [])) + sum(try([for v in values(var.masters_count) : v], [])) + sum(try([for v in values(var.data_voters_count) : v], [])) + sum(try([for v in values(var.data_voters_blue_count) : v], [])) +  sum(try([for v in values(var.datas_count) : v], [])) +  sum(try([for v in values(var.datas_blue_count) : v], [])) == 0
+  singlenode_mode = sum(values(var.masters_blue_count)) + sum(values(var.masters_count)) + sum(values(var.data_voters_count)) + sum(values(var.data_voters_blue_count)) +  sum(values(var.datas_count)) +  sum(values(var.datas_blue_count)) == 0
 
 
   alb_kibana_groups    = local.singlenode_mode ? toset(var.alb_security_groups) : toset([])
-  masters_count = local.singlenode_mode ? 0 : sum(try([for v in values(var.masters_blue_count) : v], [])) + sum(try([for v in values(var.masters_count) : v], [])) + sum(try([for v in values(var.data_voters_count) : v], [])) + sum(try([for v in values(var.data_voters_blue_count) : v], []))
+  masters_count = local.singlenode_mode ? 0 : sum(values(var.masters_blue_count)) + sum(values(var.masters_count)) + sum(values(var.data_voters_count)) + sum(values(var.data_voters_blue_count))
   
   is_cluster_bootstrapped = !var.requires_bootstrapping
 

--- a/terraform-aws/main.tf
+++ b/terraform-aws/main.tf
@@ -34,11 +34,11 @@ locals {
 
   flat_clients_subnet_ids = flatten(values(local.clients_subnet_ids))
 
-  singlenode_mode = sum(values(var.masters_blue_count)) + sum(values(var.masters_count)) + sum(values(var.data_voters_count)) + sum(values(var.data_voters_blue_count)) +  sum(values(var.datas_count)) +  sum(values(var.datas_blue_count)) == 0
+  singlenode_mode = sum(try(values(var.masters_blue_count), [])) + sum(try(values(var.masters_count), [])) + sum(try(values(var.data_voters_count), [])) + sum(try(values(var.data_voters_blue_count), [])) +  sum(try(values(var.datas_count), [])) +  sum(try(values(var.datas_blue_count), [])) == 0
 
 
   alb_kibana_groups    = local.singlenode_mode ? toset(var.alb_security_groups) : toset([])
-  masters_count = local.singlenode_mode ? 0 : sum(values(var.masters_blue_count)) + sum(values(var.masters_count)) + sum(values(var.data_voters_count)) + sum(values(var.data_voters_blue_count)) 
+  masters_count = local.singlenode_mode ? 0 : sum(try(values(var.masters_blue_count), [])) + sum(try(values(var.masters_count), [])) + sum(try(values(var.data_voters_count), [])) + sum(try(values(var.data_voters_blue_count), []))
   
   is_cluster_bootstrapped = !var.requires_bootstrapping
 

--- a/terraform-aws/main.tf
+++ b/terraform-aws/main.tf
@@ -34,11 +34,11 @@ locals {
 
   flat_clients_subnet_ids = flatten(values(local.clients_subnet_ids))
 
-  singlenode_mode = sum(try(values(var.masters_blue_count), [])) + sum(try(values(var.masters_count), [])) + sum(try(values(var.data_voters_count), [])) + sum(try(values(var.data_voters_blue_count), [])) +  sum(try(values(var.datas_count), [])) +  sum(try(values(var.datas_blue_count), [])) == 0
+  singlenode_mode = sum(try([for v in values(var.masters_blue_count) : v], [])) + sum(try([for v in values(var.masters_count) : v], [])) + sum(try([for v in values(var.data_voters_count) : v], [])) + sum(try([for v in values(var.data_voters_blue_count) : v], [])) +  sum(try([for v in values(var.datas_count) : v], [])) +  sum(try([for v in values(var.datas_blue_count) : v], [])) == 0
 
 
   alb_kibana_groups    = local.singlenode_mode ? toset(var.alb_security_groups) : toset([])
-  masters_count = local.singlenode_mode ? 0 : sum(try(values(var.masters_blue_count), [])) + sum(try(values(var.masters_count), [])) + sum(try(values(var.data_voters_count), [])) + sum(try(values(var.data_voters_blue_count), []))
+  masters_count = local.singlenode_mode ? 0 : sum(try([for v in values(var.masters_blue_count) : v], [])) + sum(try([for v in values(var.masters_count) : v], [])) + sum(try([for v in values(var.data_voters_count) : v], [])) + sum(try([for v in values(var.data_voters_blue_count) : v], []))
   
   is_cluster_bootstrapped = !var.requires_bootstrapping
 

--- a/terraform-aws/masters-blue.tf
+++ b/terraform-aws/masters-blue.tf
@@ -5,7 +5,7 @@ module "masters-blue" {
   
   # nodes
   node_count = var.masters_blue_count
-  singlenode_mode = false
+  singlenode_mode = local.singlenode_mode
   image = var.elasticsearch_blue_ami_id
   instance_type = var.master_blue_instance_type
   heap_size = var.master_blue_heap_size

--- a/terraform-aws/masters.tf
+++ b/terraform-aws/masters.tf
@@ -30,7 +30,7 @@ resource "aws_launch_template" "master" {
 }
 
 resource "aws_autoscaling_group" "master_nodes" {
-  count = length(keys(var.masters_count))
+  count = sum(values(var.masters_count)) == 0 ? 0 : 1
 
   name               = "elasticsearch-${var.es_cluster}-master-nodes-${keys(var.masters_count)[count.index]}"
   max_size           = var.masters_count[keys(var.masters_count)[count.index]]

--- a/terraform-aws/modules/nodegroup/nodegroup.tf
+++ b/terraform-aws/modules/nodegroup/nodegroup.tf
@@ -32,7 +32,7 @@ resource "aws_launch_template" "node-group" {
 }
 
 resource "aws_autoscaling_group" "nodegroup-nodes" {
-  count = length(keys(var.node_count))
+  count = sum(values(var.node_count)) == 0 ? 0 : 1
 
   name               = "elasticsearch-${var.es_cluster}-${var.name}-nodes-${keys(var.node_count)[count.index]}"
   max_size           = var.node_count[keys(var.node_count)[count.index]]

--- a/terraform-aws/terraform.tfvars.example
+++ b/terraform-aws/terraform.tfvars.example
@@ -11,6 +11,9 @@ masters_count = {
 datas_count = {
   "eu-west-1a" = 0
 }
+clients_count = {
+  "eu-west-1a" = 0
+}
 data_voters_count = {
   "eu-west-1a" = 0
 }

--- a/terraform-aws/terraform.tfvars.singlenode
+++ b/terraform-aws/terraform.tfvars.singlenode
@@ -4,6 +4,9 @@ vpc_id="vpc-0d602962c24caf5d3"
 key_name="staging-pulse-elasticsearch"
 asg_subnet_ids=["subnet-0138e23df927ce374"]
 lb_subnet_ids=["subnet-0138e23df927ce374"]
+singlenode_az="eu-west-1a"
+singlenode_subnet_id="subnet-0138e23df927ce374"
+
 masters_count = {
   "eu-west-1a" = 0
 }
@@ -17,13 +20,13 @@ data_voters_count = {
   "eu-west-1a" = 0
 }
 datas_blue_count = {
-  "eu-west-1a" = 1
+  "eu-west-1a" = 0
 }
 data_voters_blue_count = {
-  "eu-west-1a" = 2
+  "eu-west-1a" = 0
 }
 masters_blue_count = {
-  "eu-west-1a" = 1
+  "eu-west-1a" = 0
 }
 
 security_enabled = true


### PR DESCRIPTION
There doesn't seem to be a very straightforward way to get sums of the counts from empty maps. Instead, node group count variables will have to use an az with 0. Not optimal, but also not too bad.